### PR TITLE
Fix Default Pass not appearing first

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -52,7 +52,13 @@
 	//rotate to default pass:
 	PKPaymentService* paymentService = MSHookIvar<PKPaymentService*>(self, "_paymentService");
 	NSString* defaultPassID = paymentService.defaultPaymentPassUniqueIdentifier;
-	PKPass* defaultPass = [[%c(PKPassLibrary) sharedInstance] passWithUniqueID:defaultPassID];
+	// fix default pass not working
+	PKPass* defaultPass = nil;
+	for (PKPass *pass in passes) {
+		if ([pass.uniqueID isEqualToString:defaultPassID]) {
+			defaultPass = pass;
+		}
+	}
 	NSUInteger startingIndex = (defaultPass && [passes containsObject:defaultPass]) ? [passes indexOfObject:defaultPass] : 0;
 	rotateToIndex(passes, startingIndex);
 	return passes;

--- a/interfaces.h
+++ b/interfaces.h
@@ -28,7 +28,11 @@
 @property (nonatomic,readonly) CGImageRef imageRef;
 @end
 
-@interface PKPass : NSObject
+@interface PKObject : NSObject <NSCopying, NSSecureCoding>
+@property (nonatomic,copy) NSString * uniqueID;
+@end
+
+@interface PKPass : PKObject
 @property (nonatomic,readonly) PKImage* frontFaceImage;
 @end
 


### PR DESCRIPTION
For some reason, the method `[[%c(PKPassLibrary) sharedInstance] passWithUniqueID:defaultPassID]` never returned the correct default pass. From my research, it seems that looping through the passes in the array and comparing the uniqueID of each pass to the default pass uniqueID works.